### PR TITLE
Declared demo-functions `static` in order to reduce warnings.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -5,14 +5,14 @@
 #include "task.h"
 #include "queue.h"
 
-void blink1(void *p) {	
+static void blink1(void *p) {	
 	while (1) {
         PORTA.OUT ^= 0x01;
         vTaskDelay(1000);
 	}
 }
 
-void blink2(void *p) {
+static void blink2(void *p) {
 	while (1) {
 		PORTA.OUT ^= 0x02;
 		vTaskDelay(100);


### PR DESCRIPTION
Warning was:

> src\main.c(8,6): warning: no previous prototype for 'blink1' [-Wmissing-prototypes]