### PR TITLE
Adjust the referenced version of FreeRTOS in `/README.md` to "7.0.2".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # FreeRTOS on Atmel Xmega Example
 
-This code is forked from klaxalk's fork fork of yuriykulikov's FreeRTOS port. I updated it to work with FreeRTOS 8.2.2 by fixing variable naming issues. I also made this project use code from Atmel Studio's ASF Framework rather than random code driver snippits. There could still be issues but it seems to be working very well for me.
+This code is forked from klaxalk's fork fork of yuriykulikov's FreeRTOS port. I updated it to work with FreeRTOS 7.0.2 by fixing variable naming issues. I also made this project use code from Atmel Studio's ASF Framework rather than random code driver snippits. There could still be issues but it seems to be working very well for me.


### PR DESCRIPTION
As this is the version which is given in the actually used FreeRTOS files.
See for example [src/freertos/source/include/StackMacros.h:2](https://github.com/secretformula/FreeRTOS-ATxmega/blob/8f76934c0c76945f7022e40eeba054def8663621/src/freertos/source/include/StackMacros.h#L2).